### PR TITLE
#24 Improved Contact and Contact Type

### DIFF
--- a/app/models/contact_type.rb
+++ b/app/models/contact_type.rb
@@ -1,21 +1,11 @@
 # frozen_string_literal: true
 
 class ContactType < ApplicationRecord
-  # Contact Types
   CONTACT_TYPES = %w[phone email url messenger].freeze
-
-  # Contact Subtypes
-  CONTACT_SUBTYPES = {
-    phone: %w[cell mobile fax],
-    email: %w[main],
-    url: %w[landing facebook],
-    messenger: %w[skype viber telegram]
-  }.freeze
 
   has_many :contacts, dependent: :destroy
 
-  validates :title, :subtype, presence: true
-  validates :title, inclusion: { in: CONTACT_TYPES }
-  validates :subtype, inclusion: { in: ->(obj) { Array(CONTACT_SUBTYPES[obj.title.to_sym]) } }, if: :title
-  validates :title, uniqueness: { scope: :subtype }
+  validates :main_type, :subtype, presence: true
+  validates :main_type, inclusion: { in: CONTACT_TYPES }
+  validates :main_type, uniqueness: { scope: :subtype }
 end

--- a/app/validators/contact_data_validator.rb
+++ b/app/validators/contact_data_validator.rb
@@ -1,29 +1,27 @@
 # frozen_string_literal: true
 
 class ContactDataValidator < ActiveModel::EachValidator
-  # Contact Type regexps
   PHONE_REGEX = /\A(\+?\d)?[\d]+\z/i.freeze
   EMAIL_REGEX = /\A[a-z][a-z\d\_\-\.]+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/i.freeze
   URL_REGEX = /\Ahttps?:\z/i.freeze
   MESSENGER_REGEX = /\A[a-z][a-z\-_]{5,15}\z/i.freeze
 
-  # Contact Subtype regexps
-  MESSENGER_SKYPE_REGEX = /\A[a-z][a-z0-9_\-,.]{5,31}\z/i.freeze
+  MESSENGER_SKYPE_SUBREGEX = /\A[a-z][a-z0-9_\-,.]{5,31}\z/i.freeze
 
   def validate_each(record, _attribute, value)
     return unless value && record.contact_type
 
-    error_message = I18n.t('activerecord.errors.models.contact.attributes.data.informat')
+    error_message = options[:message] || I18n.t('activerecord.errors.models.contact.attributes.data.informat')
     record.errors.add(:data, error_message) unless value =~ regex(record.contact_type)
   end
 
   private
 
   def regex(contact_type)
-    regex_name = "#{contact_type.title.upcase}_#{contact_type.subtype.upcase}_REGEX"
+    regex_name = "#{contact_type.main_type.upcase}_#{contact_type.subtype.upcase}_SUBREGEX"
     ContactDataValidator.const_get(regex_name)
   rescue NameError
-    regex_name = "#{contact_type.title.upcase}_REGEX"
+    regex_name = "#{contact_type.main_type.upcase}_REGEX"
     ContactDataValidator.const_get(regex_name)
   end
 end

--- a/db/migrate/20190207100945_rename_contact_types_columns.rb
+++ b/db/migrate/20190207100945_rename_contact_types_columns.rb
@@ -1,0 +1,5 @@
+class RenameContactTypesColumns < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :contact_types, :title, :main_type
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,17 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_04_162936) do
+ActiveRecord::Schema.define(version: 2019_02_07_100945) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "contact_types", force: :cascade do |t|
-    t.string "title"
+    t.string "main_type"
     t.string "subtype"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["title", "subtype"], name: "index_contact_types_on_title_and_subtype", unique: true
+    t.index ["main_type", "subtype"], name: "index_contact_types_on_main_type_and_subtype", unique: true
   end
 
   create_table "contacts", force: :cascade do |t|

--- a/spec/factories/contact_types.rb
+++ b/spec/factories/contact_types.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :contact_type do
     factory :phone do
-      title { 'phone' }
+      main_type { 'phone' }
       subtype { 'cell' }
     end
   end

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -7,16 +7,16 @@ describe Contact, type: :model do
   it { is_expected.to validate_presence_of :contact_type }
   it { is_expected.to validate_presence_of :data }
 
-  context 'when contact_type present' do
-    let(:contact) { create(:contact) }
+  describe 'validates that :data' do
+    let(:valid_contact) { build(:contact) }
+    let(:invalid_contact) { build(:contact, data: 'invalid') }
 
-    it 'validate if valid' do
-      expect(contact).to be_valid
+    it 'is valid with expected format' do
+      expect(valid_contact).to be_valid
     end
 
-    it 'validate if invalid' do
-      contact.data = ''
-      expect(contact).not_to be_valid
+    it 'is invalid with unexpected format' do
+      expect(invalid_contact).not_to be_valid
     end
   end
 end

--- a/spec/models/contact_type_spec.rb
+++ b/spec/models/contact_type_spec.rb
@@ -2,21 +2,8 @@
 
 describe ContactType, type: :model do
   it { is_expected.to have_many(:contacts).dependent(:destroy) }
-  it { is_expected.to validate_presence_of :title }
+  it { is_expected.to validate_presence_of :main_type }
   it { is_expected.to validate_presence_of :subtype }
-  it { is_expected.to validate_inclusion_of(:title).in_array(described_class::CONTACT_TYPES) }
-  it { is_expected.to validate_uniqueness_of(:title).scoped_to(:subtype) }
-
-  context 'when title present' do
-    let(:contact_type) { build(:phone) }
-
-    it 'validate if valid' do
-      expect(contact_type).to be_valid
-    end
-
-    it 'validate if invalid' do
-      contact_type.subtype = 'not_included'
-      expect(contact_type).not_to be_valid
-    end
-  end
+  it { is_expected.to validate_inclusion_of(:main_type).in_array(described_class::CONTACT_TYPES) }
+  it { is_expected.to validate_uniqueness_of(:main_type).scoped_to(:subtype) }
 end


### PR DESCRIPTION
Fixed comments that was added by @davinciRor in #23
Removed subtype type validation as agreed with @AntonShevchuk 
Renamed ContactType attribute "title" to "main_type" for better clarity
Added customize message ability for ContactDataValidator